### PR TITLE
Store relative path if not orig source file

### DIFF
--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -197,7 +197,7 @@ class OedExposure:
                 if compression is None:
                     compression = 'csv'
 
-            filepath = filepath.with_suffix(PANDAS_COMPRESSION_MAP[compression])
+            filepath = filepath.relative_to(path).with_suffix(PANDAS_COMPRESSION_MAP[compression])
 
             oed_source.save(saved_version_name + '_' + f'{compression}',
                             {'source_type': 'filepath', 'filepath': filepath, 'extension': compression})

--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -164,7 +164,7 @@ class OedExposure:
         with open(filepath, 'w') as info_file:
             json.dump(self.info, info_file, indent='  ', default=str)
 
-    def save(self, path, version_name=None, compression=None, save_config=False):
+    def save(self, path, version_name=None, compression=None, save_config=False, relative_path=False):
         """
         helper function to save all OED data to a location with specific compression
         Args:
@@ -173,6 +173,7 @@ class OedExposure:
             path (str): output folder
             compression (str): type of compression to use
             save_config (bool): if true save the Exposure config as json
+            relative_path (bool): store file relative to config location
         """
 
         for oed_source in self.get_oed_sources():
@@ -197,10 +198,15 @@ class OedExposure:
                 if compression is None:
                     compression = 'csv'
 
-            filepath = filepath.relative_to(path).with_suffix(PANDAS_COMPRESSION_MAP[compression])
+            if relative_path:
+                filepath = filepath.relative_to(path).with_suffix(PANDAS_COMPRESSION_MAP[compression])
+                oed_source.save(saved_version_name + '_' + f'{compression}',
+                                {'source_type': 'filepath', 'filepath': filepath, 'extension': compression, 'filedir': path})
 
-            oed_source.save(saved_version_name + '_' + f'{compression}',
-                            {'source_type': 'filepath', 'filepath': filepath, 'extension': compression})
+            else:
+                filepath = filepath.with_suffix(PANDAS_COMPRESSION_MAP[compression])
+                oed_source.save(saved_version_name + '_' + f'{compression}',
+                                {'source_type': 'filepath', 'filepath': filepath, 'extension': compression})
         if save_config:
             self.save_config(Path(path, self.DEFAULT_EXPOSURE_CONFIG_NAME))
 

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -285,14 +285,16 @@ class OedSource:
                       'filepath': source,
                       }
         if source['source_type'] == 'filepath':
-            Path(source['filepath']).parents[0].mkdir(parents=True, exist_ok=True)
-            extension = source.get('extension') or ''.join(Path(source['filepath']).suffixes)
+            write_path = Path(source.get('filedir', ''), source.get('filepath'))
+            Path(write_path).parents[0].mkdir(parents=True, exist_ok=True)
+
+            extension = source.get('extension') or ''.join(Path(write_path).suffixes)
             if extension == 'parquet':
-                self.dataframe.to_parquet(source['filepath'], **source.get('write_param', {}))
+                self.dataframe.to_parquet(write_path, **source.get('write_param', {}))
             else:
                 write_param = {'index': False}
                 write_param.update(source.get('write_param', {}))
-                self.dataframe.to_csv(source['filepath'], **write_param)
+                self.dataframe.to_csv(write_path, **write_param)
         else:
             raise Exception(f"Source type {source['source_type']} is not supported")
         self.cur_version_name = version_name


### PR DESCRIPTION
## Fix for ods-tools running in OasisPlatform 

The platform fails when source file paths are stored as absolute in `exposure_info.json`. 

Because file generation is run from a temp directory, these are stored as absolute paths in `exposure_info.json` and then compressed into an an archive. 

At the loss generation step, this files are uncompressed into a new  temp dir for execution, when loading exposure the ods_tool fails because its trying to load the older (now non-existent) absolute file paths. 

Fixed by saving paths relative to `exposure_info.json` location 