### PR TITLE
Bump certifi from 2022.6.15 to 2022.12.7

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,7 @@
 #
 attrs==22.1.0
     # via pytest
-certifi==2022.6.15
+certifi==2022.12.7
     # via requests
 chardet==5.0.0
     # via -r requirements.in


### PR DESCRIPTION
Rebase of https://github.com/OasisLMF/ODS_OpenExposureData/pull/106 