### PR TITLE
fix oed source from df when column case is not the same as field name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - run: pip install pip-tools pandas pyarrow openpyxl click tox
+    - run: pip install pip-tools pandas pyarrow openpyxl==3.0.10 click tox
 
     - name: Extract Spec
       run: |

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -223,9 +223,10 @@ class OedSource:
                 to_tmp_dtype[column] = 'float'
 
         oed_df = oed_df.astype(to_tmp_dtype).astype(pd_dtype)
+        oed_df = cls.prepare_df(oed_df, column_to_field, ods_fields)
         if exposure.use_field:
             oed_df = OedSchema.use_field(oed_df, ods_fields)
-        oed_source.dataframe = cls.prepare_df(oed_df, column_to_field, ods_fields)
+        oed_source.dataframe = oed_df
         oed_source.loaded = True
         return oed_source
 

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -112,7 +112,7 @@ class OdsPackageTests(TestCase):
             'BITIV': [0, 0],
             'LocCurrency': ['GBP', 'EUR']})
 
-        exposure = OedExposure(**{'location': location_df, 'use_field':True})
+        exposure = OedExposure(**{'location': location_df, 'use_field': True})
         # check PortNumber are converted to str
         self.assertTrue((exposure.location.dataframe['PortNumber'] == '1').all())
 

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -107,16 +107,16 @@ class OdsPackageTests(TestCase):
             'LocNumber': [1, 2],
             'CountryCode': ['GB', 'FR'],
             'LocPerilsCovered': 'WTC',
-            'BuildingTIV': ['1000', '20000'],
+            'buildingtiv': ['1000', '20000'],
             'ContentsTIV': [0, 0],
             'BITIV': [0, 0],
             'LocCurrency': ['GBP', 'EUR']})
 
-        exposure = OedExposure(**{'location': location_df})
+        exposure = OedExposure(**{'location': location_df, 'use_field':True})
         # check PortNumber are converted to str
         self.assertTrue((exposure.location.dataframe['PortNumber'] == '1').all())
 
-        # check BuildingTIV converted to float
+        # check BuildingTIV converted to float and use field case
         self.assertTrue(pd.api.types.is_numeric_dtype(exposure.location.dataframe['BuildingTIV']))
 
     def test_reporting_currency(self):


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix oed source from df when column case is not the same as field name
when loading exposure data from dataframe,if the column case is different from field name an error occur as the name of the column was changed to  field name and then called with the original case.
We now apply the step in the correct order
<!--end_release_notes-->
