### PR TITLE
Set PWD as default self.exposure.working_dir

### DIFF
--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -64,7 +64,10 @@ class OedExposure:
 
         self.validation_config = validation_config
 
-        self.working_dir = working_dir
+        if not working_dir:
+            self.working_dir = Path('.').absolute()
+        else:    
+            self.working_dir = working_dir
 
         if check_oed:
             self.check()

--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -66,7 +66,7 @@ class OedExposure:
 
         if not working_dir:
             self.working_dir = Path('.').absolute()
-        else:    
+        else:
             self.working_dir = working_dir
 
         if check_oed:


### PR DESCRIPTION
<!--start_release_notes-->
### Fix default working Dir 
When initializing the **OedExposure** set `self.working_dir` to the current working directory if none is given. 

This is needed when loading relative file paths: 
```
$ ods_tools check --location SourceLocOEDPiWind10.csv
```
<!--end_release_notes-->
