### PR TITLE
test CI job to scan for broken links in markdown

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,21 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 9 * * 1'    
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/workflows/markdown-links-config.json
+          PATTERNS: |
+            **/**.md

--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+        "pattern": "^http://localhost"
+    }
+  ]
+}  


### PR DESCRIPTION
### Add CI job to scan repo for broken links 
* Test using [actions/markdown-link-check](https://github.com/marketplace/actions/markdown-link-check) to scan markdown files for broken links. 
<!--end_release_notes-->
